### PR TITLE
Struct field offsetof

### DIFF
--- a/data/codebrowser.js
+++ b/data/codebrowser.js
@@ -583,6 +583,11 @@ $(function () {
             } else {
                 tt.append($("<b />").text(title));
             }
+
+            var offset = elem.attr("offset");
+            if (offset >= 0) {
+                content += "<br/>Offset: " + escape_html(offset) + " bytes";
+            }
             if (type != "") {
                 tt.append("<br/>");
                 tt.append($("<span class='type' />").text(type));

--- a/data/codebrowser.js
+++ b/data/codebrowser.js
@@ -574,7 +574,7 @@ $(function () {
                 if (size.length === 1) {
                     content += "<br/>Size: " + escape_html(size.text()) + " bytes";
                 }
-                var offset = res.find("f_offset");
+                var offset = res.find("offset");
                 if (offset.length === 1) {
                     content += "<br/>Offset: " + escape_html(offset.text() >> 3) + " bytes (" + offset.text() + ")";
                 }

--- a/data/codebrowser.js
+++ b/data/codebrowser.js
@@ -586,7 +586,7 @@ $(function () {
 
             var offset = elem.attr("offset");
             if (offset >= 0) {
-                content += "<br/>Offset: " + escape_html(offset) + " bytes";
+                content += "<br/>Offset: " + escape_html(offset >> 3) + " bytes (" + offset + ")";
             }
             if (type != "") {
                 tt.append("<br/>");

--- a/data/codebrowser.js
+++ b/data/codebrowser.js
@@ -574,6 +574,10 @@ $(function () {
                 if (size.length === 1) {
                     content += "<br/>Size: " + escape_html(size.text()) + " bytes";
                 }
+                var offset = res.find("f_offset");
+                if (offset.length === 1) {
+                    content += "<br/>Offset: " + escape_html(offset.text() >> 3) + " bytes (" + offset.text() + ")";
+                }
             }
 
             var tt = tooltip.tooltip;
@@ -584,10 +588,6 @@ $(function () {
                 tt.append($("<b />").text(title));
             }
 
-            var offset = elem.attr("offset");
-            if (offset >= 0) {
-                content += "<br/>Offset: " + escape_html(offset >> 3) + " bytes (" + offset + ")";
-            }
             if (type != "") {
                 tt.append("<br/>");
                 tt.append($("<span class='type' />").text(type));

--- a/generator/annotator.cpp
+++ b/generator/annotator.cpp
@@ -349,7 +349,7 @@ bool Annotator::generate(clang::Sema &Sema, bool WasInDatabase)
         }
         auto itF = field_offsets.find(it.first);
         if (itF != field_offsets.end() && itF->second != -1) {
-            myfile << "<f_offset>"<< itF->second <<"</f_offset>\n";
+            myfile << "<offset>"<< itF->second <<"</offset>\n";
         }
         auto range =  commentHandler.docs.equal_range(it.first);
         for (auto it2 = range.first; it2 != range.second; ++it2) {

--- a/generator/annotator.cpp
+++ b/generator/annotator.cpp
@@ -651,12 +651,12 @@ void Annotator::addReference(const std::string &ref, clang::SourceLocation refLo
         if (size >= 0) {
             structure_sizes[ref] = size;
         }
-        ssize_t offset = getFieldOffset(decl);
-        if (offset >= 0) {
-            field_offsets[ref] = offset;
-        }
         references[ref].push_back( std::make_tuple(dt, refLoc, typeRef) );
         if (dt != Use) {
+            ssize_t offset = getFieldOffset(decl);
+            if (offset >= 0) {
+                field_offsets[ref] = offset;
+            }
             clang::FullSourceLoc fulloc(decl->getLocStart(), getSourceMgr());
             commentHandler.decl_offsets.insert({ fulloc.getSpellingLoc(), {ref, true} });
         }

--- a/generator/annotator.cpp
+++ b/generator/annotator.cpp
@@ -94,8 +94,7 @@ ssize_t getFieldOffset(const clang::NamedDecl* decl)
 {
     const clang::FieldDecl* fd = llvm::dyn_cast<clang::FieldDecl>(decl);
     if (fd) {
-        /** XXX: Return size in bytes */
-        return decl->getASTContext().getFieldOffset(fd) >> 3;
+        return decl->getASTContext().getFieldOffset(fd);
     }
     return -1;
 }

--- a/generator/annotator.h
+++ b/generator/annotator.h
@@ -87,6 +87,7 @@ private:
     // ref -> [ what, loc, typeRef ]
     std::map<std::string, std::vector<std::tuple<DeclType, clang::SourceLocation, std::string>>> references;
     std::map<std::string, ssize_t> structure_sizes;
+    std::map<std::string, ssize_t> field_offsets;
     std::unordered_map<pathTo_cache_key_t, std::string> pathTo_cache;
     CommentHandler commentHandler;
 


### PR DESCRIPTION
Here is patchset that will show value of `offsetof(struct A, internalField)`
in bytes(bits) too, it is useful for debugging.

But html for this is not as good as could be,
so if you could fix this on top of this that would be great,
otherwise I will fix this later by my own.
(I've sent patches in case if I will forget later.)

Thanks!