### PR TITLE
Struct field offsetof v6

### DIFF
--- a/data/codebrowser.js
+++ b/data/codebrowser.js
@@ -617,6 +617,10 @@ $(function () {
                     uses = undefined; // free memory
                     return false;
                 }
+                var offset = res.find("offset");
+                if (offset.length === 1) {
+                    content += "<br/>Offset: " + escape_html(offset.text() >> 3) + " bytes (" + offset.text() + ")";
+                }
             }
 
             tt.empty();

--- a/generator/annotator.h
+++ b/generator/annotator.h
@@ -87,6 +87,7 @@ private:
     // ref -> [ what, loc, typeRef ]
     std::map<std::string, std::vector<std::tuple<DeclType, clang::SourceLocation, std::string>>> references;
     std::map<std::string, ssize_t> structure_sizes;
+    std::map<std::string, ssize_t> field_offsets;
     std::unordered_map<pathTo_cache_key_t, std::string> pathTo_cache;
     CommentHandler commentHandler;
 

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -86,6 +86,15 @@ struct MyClass /* ??? */ :  MyBase {
     operator std::string() const { return m(); }
 };
 
+/**
+ * Regression for getFieldOffset(), founded during processing `struct _IO_FILE`
+ */
+struct ForwardDeclareWillBeDeclaredAfter;
+struct ForwardDeclareWillBeDeclaredAfter
+{
+    int mustBailHere;
+};
+
 
 /*!
  * yo


### PR DESCRIPTION
Fixes all the dark sides of #19:
- rebased on top of upstream
- commits were squashed
- commits messages were rewritten