### PR TITLE
cmake: FindClang: accept 3.7

### DIFF
--- a/cmake/modules/FindClang.cmake
+++ b/cmake/modules/FindClang.cmake
@@ -35,6 +35,10 @@ FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCore)
 FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerFrontend)
 FIND_AND_ADD_CLANG_LIB(clangSema)
 FIND_AND_ADD_CLANG_LIB(clangRewriteCore)
+# clang 3.7
+FIND_AND_ADD_CLANG_LIB(clangRewriteFrontend)
+FIND_AND_ADD_CLANG_LIB(clangASTMatchers)
+FIND_AND_ADD_CLANG_LIB(clangToolingCore)
 
 
 


### PR DESCRIPTION
Otherwise
```
/usr/bin/ld: warning: libclangRewriteFrontend.so.3, needed by llvm/.cmake-v2/lib/libclangFrontendTool.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libclangASTMatchers.so.3, needed by llvm/.cmake-v2/lib/libclangTooling.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libclangToolingCore.so.3, needed by llvm/.cmake-v2/lib/libclangTooling.so, not found (try using -rpath or -rpath-link)
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::MatchFinder::MatchCallback::~MatchCallback()'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::RewriteTestAction'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::tooling::Replacement::Replacement(clang::SourceManager const&, clang::CharSourceRange const&, llvm::StringRef)'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `vtable for clang::ast_matchers::MatchFinder::MatchCallback'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::DynTypedMatcher::constructVariadic(clang::ast_matchers::internal::DynTypedMatcher::VariadicOperator, std::vector<clang::ast_matchers::internal::DynTypedMatcher, std
::allocator<clang::ast_matchers::internal::DynTypedMatcher> >)'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::tooling::applyAllReplacements(std::set<clang::tooling::Replacement, std::less<clang::tooling::Replacement>, std::allocator<clang::tooling::Replacement> > const&, clang::Rewriter&)'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::FixItRecompile'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::DynTypedMatcher::dynCastTo(clang::ast_type_traits::ASTNodeKind) const'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::RewriteMacrosAction'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::tooling::operator<(clang::tooling::Replacement const&, clang::tooling::Replacement const&)'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::MatchFinder::MatchCallback::getID() const'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `clang::FixItAction::FixItAction()'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::RewriteIncludesAction'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::BoundNodesTreeBuilder::addMatch(clang::ast_matchers::internal::BoundNodesTreeBuilder const&)'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::HasNameMatcher::HasNameMatcher(llvm::StringRef)'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::DynTypedMatcher::matches(clang::ast_type_traits::DynTypedNode const&, clang::ast_matchers::internal::ASTMatchFinder*, clang::ast_matchers::internal::BoundNodesTreeB
uilder*) const'
llvm/.cmake-v2/lib/libclangTooling.so: undefined reference to `clang::ast_matchers::internal::DynTypedMatcher::trueMatcher(clang::ast_type_traits::ASTNodeKind)'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::RewriteObjCAction'
llvm/.cmake-v2/lib/libclangFrontendTool.so: undefined reference to `vtable for clang::HTMLPrintAction'
```

Also there are some issues with command line options (conflicts, since llvm have some defaults from some point):
```
LLVM ERROR: inconsistency in registered CommandLine options
```

You could pick one of the following patches to fix this:
https://github.com/azat/woboq_codebrowser/commit/6361d6c3fcb8f67d634b9f639244d7267607d90e # very bad idea
https://github.com/azat/woboq_codebrowser/commit/8def87a5fc5ff0ae360b445749edec09a0744120 # -Wl,--as-needed

(Also I'm working on linking generator only with libs that used there, to avoid such hacks, but this will need more time).