### PR TITLE
Missing include (incomplete type clang::BlockDecl in is_abstract)

### DIFF
--- a/generator/preprocessorcallback.h
+++ b/generator/preprocessorcallback.h
@@ -24,6 +24,7 @@
 #include <clang/Lex/PPCallbacks.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Basic/Version.h>
+#include <clang/AST/Decl.h>
 
 namespace clang {
 class Preprocessor;


### PR DESCRIPTION
from /home/rootdev/woboq/woboq_codebrowser/generator/preprocessorcallback.cpp:22:
/usr/include/c++/5/type_traits: In instantiation of ‘struct std::is_abstract<clang::BlockDecl>’:

Seen with clang-3.8 and GCC 5.3.1