### PR TITLE
Fixes compilation error with clang(++)9.

### DIFF
--- a/generator/preprocessorcallback.cpp
+++ b/generator/preprocessorcallback.cpp
@@ -105,7 +105,7 @@ void PreprocessorCallback::MacroExpands(const clang::Token& MacroNameTok,
     PP.setPragmasEnabled(false);
     seenPragma = false;
 
-#if CLANG_VERSION_MAJOR == 9
+#if CLANG_VERSION_MAJOR >= 9
     PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false, /*IsReinject=*/false);
 #elif CLANG_VERSION_MAJOR != 3 || CLANG_VERSION_MINOR >= 9
     PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false);

--- a/generator/preprocessorcallback.cpp
+++ b/generator/preprocessorcallback.cpp
@@ -105,7 +105,9 @@ void PreprocessorCallback::MacroExpands(const clang::Token& MacroNameTok,
     PP.setPragmasEnabled(false);
     seenPragma = false;
 
-#if CLANG_VERSION_MAJOR != 3 || CLANG_VERSION_MINOR >= 9
+#if CLANG_VERSION_MAJOR == 9
+    PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false, /*IsReinject=*/false);
+#elif CLANG_VERSION_MAJOR != 3 || CLANG_VERSION_MINOR >= 9
     PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false);
 #else
     PP.EnterTokenStream(tokens.data(), tokens.size(), false, false);


### PR DESCRIPTION
Preprocessor API _EnterTokenStream_ prototype changes with clang(++)9, leading to this compilation error:

```
$ make
Scanning dependencies of target codebrowser_generator
[  8%] Building CXX object generator/CMakeFiles/codebrowser_generator.dir/main.cpp.o
[ 16%] Building CXX object generator/CMakeFiles/codebrowser_generator.dir/projectmanager.cpp.o
[ 25%] Building CXX object generator/CMakeFiles/codebrowser_generator.dir/annotator.cpp.o
[ 33%] Building CXX object generator/CMakeFiles/codebrowser_generator.dir/generator.cpp.o
[ 41%] Building CXX object generator/CMakeFiles/codebrowser_generator.dir/preprocessorcallback.cpp.o
./woboq_codebrowser/generator/preprocessorcallback.cpp: In member function ‘virtual void PreprocessorCallback::MacroExpands(const clang::Token&, PreprocessorCallback::MyMacroDefinition, clang::SourceRange, const clang::MacroArgs*)’:
./woboq_codebrowser/generator/preprocessorcallback.cpp:109:64: error: no matching function for call to ‘clang::Preprocessor::EnterTokenStream(std::vector<clang::Token, std::allocator<clang::Token> >&, bool)’
     PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false);
```
According to the [documentation](https://clang.llvm.org/doxygen/classclang_1_1Preprocessor.html#a4d5e2474ea91247a44f3c0722b188616), a boolean is added in the prototype.

As I don't really know woboq internals + how clang is going to evolve in future minor revisions, I added a preprocessor macro handling clang9 case.

clang revision:
```
$ clang --version
clang version 9.0.0 (https://github.com/llvm/llvm-project.git c3dbe2397792302232114ebb15507c3977b605d2)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/local/bin
```

Thanks for this awesome project :+1:
