### PR TITLE
Support Clang 11

### DIFF
--- a/generator/annotator.cpp
+++ b/generator/annotator.cpp
@@ -933,9 +933,17 @@ std::pair< std::string, std::string > Annotator::getReferenceAndTitle(clang::Nam
                 && !llvm::StringRef(qualName).startswith("__")) {
             llvm::raw_string_ostream s(cached.first);
             if (llvm::isa<clang::CXXDestructorDecl>(decl)) {
+#if CLANG_VERSION_MAJOR >= 11
+                mangle->mangleName(clang::GlobalDecl(llvm::cast<clang::CXXDestructorDecl>(decl), clang::Dtor_Complete), s);
+#else
                 mangle->mangleCXXDtor(llvm::cast<clang::CXXDestructorDecl>(decl), clang::Dtor_Complete, s);
+#endif
             } else if (llvm::isa<clang::CXXConstructorDecl>(decl)) {
+#if CLANG_VERSION_MAJOR >= 11
+                mangle->mangleName(clang::GlobalDecl(llvm::cast<clang::CXXConstructorDecl>(decl), clang::Ctor_Complete), s);
+#else
                 mangle->mangleCXXCtor(llvm::cast<clang::CXXConstructorDecl>(decl), clang::Ctor_Complete, s);
+#endif
             } else {
                 mangle->mangleName(decl, s);
             }
@@ -965,7 +973,7 @@ std::pair< std::string, std::string > Annotator::getReferenceAndTitle(clang::Nam
             std::replace(cached.first.begin(), cached.first.end(), '>' , '}');
         }
         llvm::SmallString<64> buffer;
-        cached.second = Generator::escapeAttr(qualName, buffer);
+        cached.second = std::string(Generator::escapeAttr(qualName, buffer));
 
         if (cached.first.size() > 170) {
             // If the name is too big, truncate it and add the hash at the end.

--- a/generator/filesystem.cpp
+++ b/generator/filesystem.cpp
@@ -159,7 +159,7 @@ std::string naive_uncomplete(llvm::StringRef base, llvm::StringRef path) {
     using namespace llvm;
     if (sys::path::has_root_path(path)){
         if (sys::path::root_path(path) != sys::path::root_path(base)) {
-            return path;
+            return std::string(path);
         } else {
             return naive_uncomplete(sys::path::relative_path(base), sys::path::relative_path(path));
         }
@@ -167,7 +167,7 @@ std::string naive_uncomplete(llvm::StringRef base, llvm::StringRef path) {
         if (sys::path::has_root_path(base)) {
             std::cerr << "naive_uncomplete(" << base.str() << "," << path.str()
                       << "): cannot uncomplete a path relative path from a rooted base" << std::endl;
-            return path;
+            return std::string(path);
         } else {
             auto path_it = sys::path::begin(path);
             auto path_it_end = sys::path::end(path);
@@ -182,7 +182,7 @@ std::string naive_uncomplete(llvm::StringRef base, llvm::StringRef path) {
                 sys::path::append(result, "..");
             }
             sys::path::append(result, path_it, path_it_end);
-            return result.str();
+            return std::string(result.str());
         }
     }
 }

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -424,7 +424,7 @@ int main(int argc, const char **argv) {
         }
 
         if (ProjectPaths.empty()) {
-            ProjectInfo info { llvm::sys::path::filename(DirName), DirName.str() };
+            ProjectInfo info { std::string(llvm::sys::path::filename(DirName)), std::string(DirName.str()) };
             projectManager.addProject(std::move(info));
         }
 #else
@@ -482,7 +482,7 @@ int main(int argc, const char **argv) {
             // TODO: Try to find a command line for a file in the same path
             std::cerr << "Delayed " << file << "\n";
             Progress--;
-            NotInDB.push_back(filename.str());
+            NotInDB.push_back(std::string(filename.str()));
             continue;
         }
 

--- a/generator/preprocessorcallback.cpp
+++ b/generator/preprocessorcallback.cpp
@@ -24,6 +24,7 @@
 #include <clang/Lex/Token.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/Preprocessor.h>
+#include <clang/Basic/FileManager.h>
 #include <clang/Basic/Version.h>
 #include <llvm/ADT/Twine.h>
 #include "stringbuilder.h"

--- a/generator/projectmanager.cpp
+++ b/generator/projectmanager.cpp
@@ -111,7 +111,7 @@ std::string ProjectManager::includeRecovery(llvm::StringRef includeName, llvm::S
     llvm::StringRef includeFileName = llvm::sys::path::filename(includeName);
     std::string resolved;
     int weight = -1000;
-    auto range = includeRecoveryCache.equal_range(includeFileName);
+    auto range = includeRecoveryCache.equal_range(std::string(includeFileName));
     for (auto it = range.first; it != range.second; ++it) {
         llvm::StringRef candidate(it->second);
         unsigned int suf_len = 0;
@@ -141,7 +141,7 @@ std::string ProjectManager::includeRecovery(llvm::StringRef includeName, llvm::S
             continue;
 
         weight = w;
-        resolved = candidate;
+        resolved = std::string(candidate);
     }
     return resolved;
 #else


### PR DESCRIPTION
Two changes are needed:
* LLVM strings stopped being implicitly converted to `std::string` so adding explicit conversion (shouldn't hurt older versions)
* As of https://reviews.llvm.org/D75700 the mangler interface changed a bit (guarded by the version)