### PR TITLE
Add support for clang >= 19

### DIFF
--- a/generator/preprocessorcallback.cpp
+++ b/generator/preprocessorcallback.cpp
@@ -248,6 +248,9 @@ void PreprocessorCallback::InclusionDirective(
     clang::SourceLocation HashLoc, const clang::Token &IncludeTok, llvm::StringRef FileName,
     bool IsAngled, clang::CharSourceRange FilenameRange, clang::OptionalFileEntryRef File,
     llvm::StringRef SearchPath, llvm::StringRef RelativePath, const clang::Module *Imported,
+#if CLANG_VERSION_MAJOR >= 19
+    bool ModuleImported,
+#endif
     clang::SrcMgr::CharacteristicKind)
 {
     if (!HashLoc.isValid() || !HashLoc.isFileID() || !File)

--- a/generator/preprocessorcallback.h
+++ b/generator/preprocessorcallback.h
@@ -61,8 +61,11 @@ public:
                             llvm::StringRef FileName, bool IsAngled,
                             clang::CharSourceRange FilenameRange, clang::OptionalFileEntryRef File,
                             llvm::StringRef SearchPath, llvm::StringRef RelativePath,
-                            const clang::Module *Imported,
-                            clang::SrcMgr::CharacteristicKind) override;
+                            const clang::Module *SuggestedModule,
+#if CLANG_VERSION_MAJOR >= 19
+                            bool ModuleImported,
+#endif
+                            clang::SrcMgr::CharacteristicKind FileType) override;
 
     void PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntroducerKind Introducer) override
     {


### PR DESCRIPTION
There is only a small change in the signature of `PPCallbacks::InclusionDirective` that needed to be addressed.